### PR TITLE
arduino camel case fix

### DIFF
--- a/platformio/src/analyzer/acquisition.h
+++ b/platformio/src/analyzer/acquisition.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 #include <stdio.h>
 #include <string.h>
 #include "misc/circular_buffer.h"

--- a/platformio/src/display/bssr_tables.h
+++ b/platformio/src/display/bssr_tables.h
@@ -1,7 +1,7 @@
 // Lookup tables to drive the 16 bits parallel output.
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 namespace bssr_tables {
 

--- a/platformio/src/display/tft_driver.cpp
+++ b/platformio/src/display/tft_driver.cpp
@@ -2,7 +2,7 @@
 
 #include "tft_driver.h"
 
-#include <arduino.h>
+#include <Arduino.h>
 
 #include "bssr_tables.h"
 #include "hal/gpio.h"

--- a/platformio/src/display/tft_driver.h
+++ b/platformio/src/display/tft_driver.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 
 namespace tft_driver {

--- a/platformio/src/display/touch_driver.cpp
+++ b/platformio/src/display/touch_driver.cpp
@@ -5,7 +5,7 @@
 
 // TODO: check hal errors.
 
-#include <arduino.h>
+#include <Arduino.h>
 
 #include "hal/i2c.h"
 

--- a/platformio/src/display/touch_driver.h
+++ b/platformio/src/display/touch_driver.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <arduino.h>
+#include <Arduino.h>
 
 namespace touch_driver {
 extern void test();


### PR DESCRIPTION
Need uppercase Arduino.h so compiles on Linux.

Have tested build on Debian & Win10, but my hardware still in the mail, so have not uploaded & tested.